### PR TITLE
Bugfix - datetime issue

### DIFF
--- a/models/tasksModels.js
+++ b/models/tasksModels.js
@@ -70,7 +70,7 @@ class Tasks {
 		var entry = {
 			name: name,
 			type: type,
-			date: date,
+			date: new Date(date).toLocaleDateString("en-gb"),
 			startTime: startTime,
 			endTime: endTime,
 			username: username,
@@ -146,7 +146,7 @@ class Tasks {
 					$set: {
 						name: name,
 						type: type,
-						date: date,
+						date: new Date(date).toLocaleDateString("en-gb"),
 						startTime: startTime,
 						endTime: endTime,
 					},


### PR DESCRIPTION
Fixed an issue where new tasks being added to the database would have
a wrong datetime string. Fix was to change the datatype from string to
datetime when adding new entries/tasks.